### PR TITLE
Use custom property for contentInsets, not collectionView.contentInsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## master
+##### Bugfix
+* Layout was not treating `collectionView.contentInset` collectly.  
+  Use custom field for contentInset, not collectionView.contentInset.  
+  `collectionView.contentInset` changes before layout.
+
 ## 0.1.3
 ##### Bugfix
 * Fixed wrong header insets

--- a/Example/Shared/ViewController.swift
+++ b/Example/Shared/ViewController.swift
@@ -22,9 +22,6 @@ class ViewController: UIViewController, UICollectionViewDelegate {
             if #available(iOS 11.0, *) {
                 collectionView.contentInsetAdjustmentBehavior = .never
             }
-            #if os(tvOS)
-                collectionView.contentInset = UIEdgeInsets(top: 0, left: 30, bottom: 0, right: 30)
-            #endif
         }
     }
     private var sections: [Section] = (0..<5).map { _ in Section(items: (0..<1).map { $0 }) }
@@ -68,11 +65,14 @@ class ViewController: UIViewController, UICollectionViewDelegate {
             self.collectionView.insertItems(at: add1 + add2)
         }, completion: nil)
     }
-//    @IBOutlet weak var layout: HorizontalStickyHeaderLayout! {
-//        didSet {
-//            layout.delegate = self
-//        }
-//    }
+    @IBOutlet weak var layout: HorizontalStickyHeaderLayout! {
+        didSet {
+            layout.delegate = self
+            #if os(tvOS)
+                layout.contentInset = UIEdgeInsets(top: 0, left: 30, bottom: 0, right: 30)
+            #endif
+        }
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
         collectionView.dataSource = self

--- a/Example/tvOS/Base.lproj/Main.storyboard
+++ b/Example/tvOS/Base.lproj/Main.storyboard
@@ -112,6 +112,7 @@
                     </view>
                     <connections>
                         <outlet property="collectionView" destination="aoc-tg-B04" id="Ata-e8-h54"/>
+                        <outlet property="layout" destination="a92-P8-oo6" id="7GA-ib-73b"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/HorizontalStickyHeaderLayout/HorizontalStickyHeaderLayout.swift
+++ b/HorizontalStickyHeaderLayout/HorizontalStickyHeaderLayout.swift
@@ -29,6 +29,7 @@ public protocol HorizontalStickyHeaderLayoutDelegate: class {
 public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
     private var cacheForItems = [Layout]()
     public weak var delegate: HorizontalStickyHeaderLayoutDelegate?
+    public var contentInset = UIEdgeInsets.zero
 
     // MARK: UICollectionViewLayout overrides
     public override func prepare() {
@@ -51,7 +52,7 @@ public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
         cacheForItems.removeAll(keepingCapacity: true)
 
         // prepare layout for cells
-        var x: CGFloat = 0
+        var x: CGFloat = contentInset.left
         for section in 0..<cv.numberOfSections {
             let headerHeight = delegate.collectionView(cv, hshlSizeForHeaderAtSection: section).height
             let headerInsets = delegate.collectionView(cv, hshlHeaderInsetsAtSection: section)
@@ -97,7 +98,7 @@ public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
         let lastSection = cv.numberOfSections - 1
         let sectionInsets: UIEdgeInsets = delegate.collectionView(cv, hshlSectionInsetsAtSection: lastSection)
         let contentWidth = maxX + sectionInsets.right
-        let contentHeight = cv.bounds.height - cv.contentInset.top - cv.contentInset.bottom
+        let contentHeight = cv.bounds.height - contentInset.top - contentInset.bottom
         return CGSize(width: contentWidth, height: contentHeight)
     }
 
@@ -143,7 +144,7 @@ public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
                 if let firstItemAttributes = cacheForItems.first(where: { $0.indexPath == IndexPath(item: 0, section: section) }),
                     let lastItemAttributes = cacheForItems.first(where: { $0.indexPath == IndexPath(row: numberOfItems - 1, section: section) }) {
 
-                    let edgeX = cv.contentOffset.x + cv.contentInset.left + headerInsets.left
+                    let edgeX = cv.contentOffset.x + contentInset.left + headerInsets.left
                     let xByLeftBoundary = max(edgeX, firstItemAttributes.frame.minX - itemsInsets.left + headerInsets.left)
 
                     let xByRightBoundary = (lastItemAttributes.frame.maxX + itemsInsets.right) - headerSize.width - headerInsets.right

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ extension ViewController: HorizontalStickyHeaderLayoutDelegate {
 }
 ```
 
+Optionally you can define `contentInset` for outer margin.
+
+![](https://github.com/toshi0383/assets/raw/master/HorizontalStickyHeaderLayout/layout-definitions.png)
+
 See [Example](Example) for detail.
 
 # Install


### PR DESCRIPTION
It turns out that setting `collectionView.contentInset` was no-op for custom layout.
The value changes to default value (h:20, v:0) before `prepare()` is called.

```swift
collectionView.contentInset = UIEdgeInset...
```