### PR TITLE
Pop header using container view, not HeaderView itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,26 @@
+## master
+##### Breaking
+* [tvOS] Pop header using container view, not HeaderView itself [#10](https://github.com/toshi0383/HorizontalStickyHeaderLayout/pull/10) [@toshi0383](https://github.com/toshi0383)
+
+##### Bugfix
+* [tvOS] Unwanted moving header on fast scroll [#5](https://github.com/toshi0383/HorizontalStickyHeaderLayout/issues/5)
+* [tvOS] Cell's sometimes not displayed when popping header is enabled [#9](https://github.com/toshi0383/HorizontalStickyHeaderLayout/issues/9)
+
 ## 0.3.3
 ##### Bugfix
-* [tvOS] Fix unwanted popping header 2  
-  [#7](https://github.com/toshi0383/HorizontalStickyHeaderLayout/pull/7) @toshi0383
+* [tvOS] Fix unwanted popping header 2 [#7](https://github.com/toshi0383/HorizontalStickyHeaderLayout/pull/7) [@toshi0383](https://github.com/toshi0383)
 
 ## 0.3.2
 ##### Bugfix
-* [tvOS] Fix unwanted popping header  
-  [#6](https://github.com/toshi0383/HorizontalStickyHeaderLayout/pull/6) @toshi0383
+* [tvOS] Fix unwanted popping header [#6](https://github.com/toshi0383/HorizontalStickyHeaderLayout/pull/6) [@toshi0383](https://github.com/toshi0383)
 
 ## 0.3.1
 ##### Bugfix
-* [tvOS] Fix unwanted scrolling header  
-  [#3](https://github.com/toshi0383/HorizontalStickyHeaderLayout/pull/3) @toshi0383
+* [tvOS] Fix unwanted scrolling header [#3](https://github.com/toshi0383/HorizontalStickyHeaderLayout/pull/3) [@toshi0383](https://github.com/toshi0383)
 
 ## 0.3.0
 ##### Feature
-* [tvOS] Animate Header PositionY for tvOS Focus  
-  [#2](https://github.com/toshi0383/HorizontalStickyHeaderLayout/pull/2) @toshi0383
+* [tvOS] Animate Header PositionY for tvOS Focus [#2](https://github.com/toshi0383/HorizontalStickyHeaderLayout/pull/2) [@toshi0383](https://github.com/toshi0383)
 
 ## 0.2.0
 ##### Bugfix

--- a/Example/Shared/HeaderView.swift
+++ b/Example/Shared/HeaderView.swift
@@ -11,4 +11,27 @@ import UIKit
 final class HeaderView: UICollectionReusableView {
     static let reuseID = "HeaderView"
     @IBOutlet weak var label: UILabel?
+    @IBOutlet weak var container: UIView?
+    @IBOutlet weak var containerTop: NSLayoutConstraint?
+    func popHeader() {
+        updateContainerTop(-20)
+    }
+    func unpopHeader() {
+        // EaseOut + 0.5 duration for unpopping animation
+        updateContainerTop(0, duration: 0.5)
+    }
+    private func updateContainerTop(_ constant: CGFloat, duration: Double? = nil) {
+        guard let containerTop = containerTop, containerTop.constant != constant else {
+            return
+        }
+        containerTop.constant = constant
+
+        if let duration = duration {
+            UIView.animate(withDuration: duration, delay: 0, options: [.curveEaseOut], animations: {
+                self.layoutIfNeeded()
+            }, completion: nil)
+        } else {
+            self.layoutIfNeeded()
+        }
+    }
 }

--- a/Example/tvOS/HeaderView.xib
+++ b/Example/tvOS/HeaderView.xib
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.XIB" version="3.0" toolsVersion="13196" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder.AppleTV.XIB" version="3.0" toolsVersion="13529" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="appleTV" orientation="landscape">
         <adaptation id="light"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,20 +14,33 @@
             <rect key="frame" x="0.0" y="0.0" width="1920" height="50"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L3e-B4-Xz4">
-                    <rect key="frame" x="0.0" y="0.0" width="91" height="50"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="38"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y2K-Mx-Abg">
+                    <rect key="frame" x="0.0" y="0.0" width="1920" height="38"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L3e-B4-Xz4">
+                            <rect key="frame" x="0.0" y="0.0" width="91" height="38"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="38"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="L3e-B4-Xz4" secondAttribute="bottom" id="H6p-Hh-CYQ"/>
+                        <constraint firstItem="L3e-B4-Xz4" firstAttribute="leading" secondItem="y2K-Mx-Abg" secondAttribute="leading" id="Xqx-1m-872"/>
+                        <constraint firstItem="L3e-B4-Xz4" firstAttribute="top" secondItem="y2K-Mx-Abg" secondAttribute="top" id="cI7-YE-nbW"/>
+                        <constraint firstAttribute="height" constant="38" id="g4L-UF-fv9"/>
+                    </constraints>
+                </view>
             </subviews>
             <constraints>
-                <constraint firstItem="L3e-B4-Xz4" firstAttribute="leading" secondItem="IuV-QN-8XL" secondAttribute="leading" id="Y7j-5M-EJz"/>
-                <constraint firstAttribute="bottom" secondItem="L3e-B4-Xz4" secondAttribute="bottom" id="cXV-NY-5Qf"/>
-                <constraint firstItem="L3e-B4-Xz4" firstAttribute="top" secondItem="IuV-QN-8XL" secondAttribute="top" id="tyR-np-ctZ"/>
+                <constraint firstAttribute="trailing" secondItem="y2K-Mx-Abg" secondAttribute="trailing" id="3kK-00-04V"/>
+                <constraint firstItem="y2K-Mx-Abg" firstAttribute="top" secondItem="IuV-QN-8XL" secondAttribute="top" id="bJs-SK-OvQ"/>
+                <constraint firstItem="y2K-Mx-Abg" firstAttribute="leading" secondItem="IuV-QN-8XL" secondAttribute="leading" id="p8W-Pd-N5B"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="7Hi-e8-9NQ"/>
             <connections>
+                <outlet property="container" destination="y2K-Mx-Abg" id="3ff-Wn-dQG"/>
+                <outlet property="containerTop" destination="bJs-SK-OvQ" id="vCd-hl-hX5"/>
                 <outlet property="label" destination="L3e-B4-Xz4" id="KL4-oT-FEe"/>
             </connections>
             <point key="canvasLocation" x="199" y="390"/>

--- a/HorizontalStickyHeaderLayout/HorizontalStickyHeaderLayout.swift
+++ b/HorizontalStickyHeaderLayout/HorizontalStickyHeaderLayout.swift
@@ -30,7 +30,10 @@ public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
     private var cacheForItems = [Layout]()
     public weak var delegate: HorizontalStickyHeaderLayoutDelegate?
     public var contentInset = UIEdgeInsets.zero
-    public var headerYDeltaOnFocus: CGFloat = -20
+    public var poppingHeaderIndexPaths: [IndexPath] = []
+    public func updatePoppingHeaderIndexPaths() {
+        _ = getAttributesForHeaders()
+    }
 
     // MARK: UICollectionViewLayout overrides
     public override func prepare() {
@@ -135,6 +138,7 @@ public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
             fatalError()
         }
         var attributes = [UICollectionViewLayoutAttributes]()
+        var poppingHeaderSections: [Int] = []
         for section in 0..<cv.numberOfSections {
             var x: CGFloat = 0
             let headerSize = delegate.collectionView(cv, hshlSizeForHeaderAtSection: section)
@@ -173,9 +177,15 @@ public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
                     return false
                 #endif
             }
-            let yDeltaForFocus: CGFloat = shouldPopHeader() ? headerYDeltaOnFocus : 0
+            if shouldPopHeader() {
+                poppingHeaderSections.append(section)
+            } else {
+                if let s = poppingHeaderSections.index(of: section) {
+                    poppingHeaderSections.remove(at: s)
+                }
+            }
             let frame = CGRect(x: x,
-                               y: headerInsets.top + yDeltaForFocus,
+                               y: headerInsets.top,
                                width: headerSize.width,
                                height: headerSize.height)
             let attr = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
@@ -184,6 +194,7 @@ public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
             attributes.append(attr)
             x += headerInsets.right
         }
+        self.poppingHeaderIndexPaths = poppingHeaderSections.map { IndexPath(item: 0, section: $0) }
         return attributes
     }
 }

--- a/HorizontalStickyHeaderLayout/HorizontalStickyHeaderLayout.swift
+++ b/HorizontalStickyHeaderLayout/HorizontalStickyHeaderLayout.swift
@@ -30,7 +30,7 @@ public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
     private var cacheForItems = [Layout]()
     public weak var delegate: HorizontalStickyHeaderLayoutDelegate?
     public var contentInset = UIEdgeInsets.zero
-    public var poppingHeaderIndexPaths: [IndexPath] = []
+    public private(set) var poppingHeaderIndexPaths: [IndexPath] = []
     public func updatePoppingHeaderIndexPaths() {
         _ = getAttributesForHeaders()
     }

--- a/README.md
+++ b/README.md
@@ -57,23 +57,24 @@ See [Example](Example) for detail.
 # Animated header Y position for tvOS for free!
 ![](https://github.com/toshi0383/assets/blob/master/HorizontalStickyHeaderLayout/sticky-animated-header-for-tvos.gif?raw=true)
 
-Currently `invalidateLayout()` call is required. Call it and then `layoutIfNeeded()` inside coordinatedAnimation block to correctly trigger animation **iff it's not during fast scroll**. See [#5](https://github.com/toshi0383/HorizontalStickyHeaderLayout/issues/5#issuecomment-342332880) for more information.
+- Call `invalidateLayout()`
+- Tell layout to recalculate the popping headers indexPaths
+- Get indexPaths to pop, and animate by yourself.
+
+See [Example](Example) for recommended implementation.
 
 ```swift
-    // Either in UICollectionViewDelegate or in UIFocusEnvironment's didUpdateFocus method.
-    func collectionView(_ collectionView: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+    // Either in UICollectionViewDelegate or this override method.
+    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
         self.collectionView.collectionViewLayout.invalidateLayout()
+        layout.updatePoppingHeaderIndexPaths()
+        let (pop, unpop) = self.getHeaders(poppingHeadersIndexPaths: self.layout.poppingHeaderIndexPaths)
+        unpop.forEach { $0.unpopHeader() }
         coordinator.addCoordinatedAnimations({
-            if !self.isFastScrolling {
-                self.collectionView.layoutIfNeeded()
-            }
+            pop.forEach { $0.popHeader() }
         }, completion: nil)
+        super.didUpdateFocus(in: context, with: coordinator)
     }
-```
-
-Modify `headerYDeltaOnFocus` if you need. It defaults to `-20`. (Set `0` to disable this behavior.)
-```swift
-(collectionView.collectionViewLayout as? HorizontalStickyHeaderLayout)!.headerYDeltaOnFocus = -25
 ```
 
 # Install


### PR DESCRIPTION
It turns-out that animating supplementaryView itself is troublesome.
This PR changes and demonstrates how to handle HeaderView animation.

That's said, you should always animate HeaderView's child view, not HeaderView itself.

![10](https://user-images.githubusercontent.com/6007952/32826220-e5a8e42c-ca2a-11e7-880e-634942771724.gif)

Solves #5
Solves #9

# Removed
- [x] `var headerYDeltaOnFocus { get set }`

# Added
- [x] `var poppingHeaderIndexPaths: [IndexPath] { get }`
- [x] `func updatePoppingHeaderIndexPaths()`