### PR TITLE
[tvOS] Notify on poppingHeaderIndexPaths change on scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ##### Bugfix
 * [tvOS] Unwanted moving header on fast scroll [#5](https://github.com/toshi0383/HorizontalStickyHeaderLayout/issues/5)
 * [tvOS] Cell's sometimes not displayed when popping header is enabled [#9](https://github.com/toshi0383/HorizontalStickyHeaderLayout/issues/9)
+* [tvOS] Notify on poppingHeaderIndexPaths change on scroll [#11](https://github.com/toshi0383/HorizontalStickyHeaderLayout/pull/11) [@toshi0383](https://github.com/toshi0383)
 
 ## 0.3.3
 ##### Bugfix

--- a/Example/Shared/HeaderView.swift
+++ b/Example/Shared/HeaderView.swift
@@ -17,21 +17,13 @@ final class HeaderView: UICollectionReusableView {
         updateContainerTop(-20)
     }
     func unpopHeader() {
-        // EaseOut + 0.5 duration for unpopping animation
-        updateContainerTop(0, duration: 0.5)
+        updateContainerTop(0)
     }
-    private func updateContainerTop(_ constant: CGFloat, duration: Double? = nil) {
+    private func updateContainerTop(_ constant: CGFloat) {
         guard let containerTop = containerTop, containerTop.constant != constant else {
             return
         }
         containerTop.constant = constant
-
-        if let duration = duration {
-            UIView.animate(withDuration: duration, delay: 0, options: [.curveEaseOut], animations: {
-                self.layoutIfNeeded()
-            }, completion: nil)
-        } else {
-            self.layoutIfNeeded()
-        }
+        self.layoutIfNeeded()
     }
 }

--- a/Example/Shared/ViewController.swift
+++ b/Example/Shared/ViewController.swift
@@ -13,6 +13,7 @@ private enum Const {
     static let numberOfItemsForEachSection = 10
     static let numberOfSections = 5
     #if os(tvOS)
+    static let unpopDuration: Double = 0.4
     static let headerSize = CGSize(width: 351, height: 38)
     static let itemSize0  = CGSize(width: 447, height: 454)
     static let itemSize1  = CGSize(width: 700, height: 700)
@@ -168,6 +169,14 @@ extension ViewController: HorizontalStickyHeaderLayoutDelegate {
     func collectionView(_ collectionView: UICollectionView, hshlSectionInsetsAtSection section: Int) -> UIEdgeInsets {
         return UIEdgeInsets(top: 0, left: Const.spacingForItems, bottom: 0, right: section == 4 ? 0 : Const.spacingForItems)
     }
+    // Popping Header
+    func collectionView(_ collectionView: UICollectionView, hshlDidUpdatePoppingHeaderIndexPaths indexPaths: [IndexPath]) {
+        let (pop, unpop) = self.getHeaders(poppingHeadersIndexPaths: self.layout.poppingHeaderIndexPaths)
+        UIView.animate(withDuration: Const.unpopDuration, delay: 0, options: [.curveEaseOut], animations: {
+            unpop.forEach { $0.unpopHeader() }
+            pop.forEach { $0.popHeader() }
+        }, completion: nil)
+    }
     func getHeaders(poppingHeadersIndexPaths indexPaths: [IndexPath]) -> (pop: [HeaderView], unpop: [HeaderView]) {
         var visible = collectionView.visibleSupplementaryViews(ofKind: UICollectionElementKindSectionHeader)
         var pop: [HeaderView] = []
@@ -182,11 +191,6 @@ extension ViewController: HorizontalStickyHeaderLayoutDelegate {
                 pop.append(header)
             }
         }
-        for view in visible {
-            if let header = view as? HeaderView {
-                header.unpopHeader()
-            }
-        }
         return (pop: pop, unpop: visible.flatMap { $0 as? HeaderView })
     }
 }
@@ -194,10 +198,11 @@ extension ViewController: HorizontalStickyHeaderLayoutDelegate {
 // MARK: Focus
 extension ViewController {
     override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-        self.collectionView.collectionViewLayout.invalidateLayout()
         layout.updatePoppingHeaderIndexPaths()
         let (pop, unpop) = self.getHeaders(poppingHeadersIndexPaths: self.layout.poppingHeaderIndexPaths)
-        unpop.forEach { $0.unpopHeader() }
+        UIView.animate(withDuration: Const.unpopDuration, delay: 0, options: [.curveEaseOut], animations: {
+            unpop.forEach { $0.unpopHeader() }
+        }, completion: nil)
         coordinator.addCoordinatedAnimations({
             pop.forEach { $0.popHeader() }
         }, completion: nil)

--- a/HorizontalStickyHeaderLayout/HorizontalStickyHeaderLayout.swift
+++ b/HorizontalStickyHeaderLayout/HorizontalStickyHeaderLayout.swift
@@ -18,12 +18,14 @@ private struct Layout {
     }
 }
 
+@objc
 public protocol HorizontalStickyHeaderLayoutDelegate: class {
     func collectionView(_ collectionView: UICollectionView, hshlSizeForItemAtIndexPath indexPath: IndexPath) -> CGSize
     func collectionView(_ collectionView: UICollectionView, hshlSectionInsetsAtSection section: Int) -> UIEdgeInsets
     func collectionView(_ collectionView: UICollectionView, hshlMinSpacingForCellsAtSection section: Int) -> CGFloat
     func collectionView(_ collectionView: UICollectionView, hshlSizeForHeaderAtSection section: Int) -> CGSize
     func collectionView(_ collectionView: UICollectionView, hshlHeaderInsetsAtSection section: Int) -> UIEdgeInsets
+    @objc optional func collectionView(_ collectionView: UICollectionView, hshlDidUpdatePoppingHeaderIndexPaths indexPaths: [IndexPath])
 }
 
 public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
@@ -31,8 +33,11 @@ public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
     public weak var delegate: HorizontalStickyHeaderLayoutDelegate?
     public var contentInset = UIEdgeInsets.zero
     public private(set) var poppingHeaderIndexPaths: [IndexPath] = []
+    private var skipDidUpdatePoppingHeaderDelegateCall: Bool = false
     public func updatePoppingHeaderIndexPaths() {
+        skipDidUpdatePoppingHeaderDelegateCall = true
         _ = getAttributesForHeaders()
+        skipDidUpdatePoppingHeaderDelegateCall = false
     }
 
     // MARK: UICollectionViewLayout overrides
@@ -195,6 +200,9 @@ public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
             x += headerInsets.right
         }
         self.poppingHeaderIndexPaths = poppingHeaderSections.map { IndexPath(item: 0, section: $0) }
+        if !skipDidUpdatePoppingHeaderDelegateCall {
+            delegate.collectionView?(cv, hshlDidUpdatePoppingHeaderIndexPaths: self.poppingHeaderIndexPaths)
+        }
         return attributes
     }
 }

--- a/README.md
+++ b/README.md
@@ -57,23 +57,33 @@ See [Example](Example) for detail.
 # Animated header Y position for tvOS for free!
 ![](https://github.com/toshi0383/assets/blob/master/HorizontalStickyHeaderLayout/sticky-animated-header-for-tvos.gif?raw=true)
 
-- Call `invalidateLayout()`
-- Tell layout to recalculate the popping headers indexPaths
-- Get indexPaths to pop, and animate by yourself.
+## How to implement
+- On focus, call `updatePoppingHeaderIndexPaths()` to recalculate the popping header indexPaths to get the latest indexPaths.
+- Listen to pop indexPaths change on scroll by implementing `collectionView(_:,hshlDidUpdatePoppingHeaderIndexPaths:)` delegate method.
+- animate container view of your header view.
 
 See [Example](Example) for recommended implementation.
 
 ```swift
     // Either in UICollectionViewDelegate or this override method.
     override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-        self.collectionView.collectionViewLayout.invalidateLayout()
         layout.updatePoppingHeaderIndexPaths()
         let (pop, unpop) = self.getHeaders(poppingHeadersIndexPaths: self.layout.poppingHeaderIndexPaths)
-        unpop.forEach { $0.unpopHeader() }
+        UIView.animate(withDuration: Const.unpopDuration, delay: 0, options: [.curveEaseOut], animations: {
+            unpop.forEach { $0.unpopHeader() }
+        }, completion: nil)
         coordinator.addCoordinatedAnimations({
             pop.forEach { $0.popHeader() }
         }, completion: nil)
         super.didUpdateFocus(in: context, with: coordinator)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, hshlDidUpdatePoppingHeaderIndexPaths indexPaths: [IndexPath]) {
+        let (pop, unpop) = self.getHeaders(poppingHeadersIndexPaths: self.layout.poppingHeaderIndexPaths)
+        UIView.animate(withDuration: Const.unpopDuration, delay: 0, options: [.curveEaseOut], animations: {
+            unpop.forEach { $0.unpopHeader() }
+            pop.forEach { $0.popHeader() }
+        }, completion: nil)
     }
 ```
 
@@ -89,8 +99,8 @@ pod "HorizontalStickyHeaderLayout"
 ```
 
 # Development
-- Xcode9
-- Swift4
+- Xcode9.1
+- Swift4.0.2
 
 # License
 MIT


### PR DESCRIPTION
Introduced a new delegate method to correctly handle popping header state.

- [x] `@objc optional func collectionView(_:,hshlDidUpdatePoppingHeaderIndexPaths:)`