### PR TITLE
Switched fatalError to assertionFailure

### DIFF
--- a/HorizontalStickyHeaderLayout/HorizontalStickyHeaderLayout.swift
+++ b/HorizontalStickyHeaderLayout/HorizontalStickyHeaderLayout.swift
@@ -51,10 +51,12 @@ public final class HorizontalStickyHeaderLayout: UICollectionViewLayout {
             }
         }
         guard let delegate = delegate else {
-            fatalError("Delegate is not set.")
+            assertionFailure("Delegate is not set.")
+            return
         }
         guard let cv = collectionView else {
-            fatalError("collectionView is not set.")
+            assertionFailure("collectionView is not set.")
+            return
         }
 
         // reset


### PR DESCRIPTION
**Motivation**

As the `HorizontalStickyHeaderLayout#prepare()` method does not have a return value, there is no practical advantage in `fatalError()`ing when either `delegate` or `collectionView` are not set over just asserting their presence.

If something goes wild, it should be arguably better for most customers to just do not see the collection view at all than to crash the app.

`assertionFailure()` offers the same class of strong guarantees against programming errors `fatalError()` does, as each developer runs his app in DEBUG mode at least once before shipping it.

So for all these reasons if will propose switching from `fatalError()` to `assertionFailure()`.